### PR TITLE
Resize dialog to resolve issue with paper-dialog defects

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "paper-date-picker",
   "dependencies": {
-    "polymer": "Polymer/polymer#master",
-    "core-animated-pages": "Polymer/core-animated-pages#master",
-    "paper-dialog": "Polymer/paper-dialog#master",
-    "paper-button": "Polymer/paper-button#master",
-    "paper-ripple": "Polymer/paper-ripple#master"
+    "polymer": "Polymer/polymer#~0.5.5",
+    "core-animated-pages": "Polymer/core-animated-pages#~0.5.5",
+    "paper-dialog": "Polymer/paper-dialog#~0.5.5",
+    "paper-button": "polymer/paper-button#~0.5.5",
+    "paper-ripple": "polymer/paper-ripple#~0.5.5"
   },
   "version": "0.1.4"
 }

--- a/paper-date-picker-dialog.html
+++ b/paper-date-picker-dialog.html
@@ -289,6 +289,7 @@ The date picker dialog fires `value-changed` and `selection-changed` events when
     dialogOpened: function(){
       this.$.datePicker.refreshScrollPosition();
       this.$.yearPicker.refreshScrollPosition();
+      this.$.dialog.resizeHandler();
     },
     
     yearChanged: function() {


### PR DESCRIPTION
Added a minor function call which resolves an issue in paper-dialog requiring it to be resized upon opening (https://github.com/Polymer/paper-dialog/issues/44).

Note that I had also inadvertently duplicated #12 while fixing this issue.
